### PR TITLE
fix/114425 - removera propriedade dangerouslyInnerHTML da descricao na listagem dos cards

### DIFF
--- a/src/pages/consulta-acervo/lista-cards-consulta-acervo/index.tsx
+++ b/src/pages/consulta-acervo/lista-cards-consulta-acervo/index.tsx
@@ -163,7 +163,6 @@ export const ListaCardsConsultaAcervo: React.FC = () => {
                       description={item.descricao}
                       ellipsis
                       exibirTooltip
-                      dangerouslyInnerHTML
                     />
 
                     <TextItemCardContentConsultaAcervo


### PR DESCRIPTION
[AB#114425](https://dev.azure.com/amcomgov/8217b3ef-9b0e-4b12-a2b0-a4fe910279ea/_workitems/edit/114425) 