### PR TITLE
Habilitar uploads de vários arquivos por padrão

### DIFF
--- a/src/components/cdep/upload/index.tsx
+++ b/src/components/cdep/upload/index.tsx
@@ -31,6 +31,7 @@ const UploadArquivosCDEP: React.FC<UploadArquivosCDEPProps> = ({
         break;
 
       default:
+        setPermiteMultiplos(true);
         break;
     }
   };


### PR DESCRIPTION
Adicionado setPermiteMultiplos(true) ao caso padrão na instrução switch, garantindo que múltiplos uploads de arquivos sejam permitidos, a menos que especificado de outra forma.