### PR TITLE
Adicionar estilos personalizados ao item de formulário do relatório d…

### DIFF
--- a/src/pages/relatorios/editora/index.tsx
+++ b/src/pages/relatorios/editora/index.tsx
@@ -13,6 +13,8 @@ import CardContent from '~/components/lib/card-content';
 import { CDEP_SELECT_EDITORA } from '~/core/constants/ids/select';
 import { CheckCircleOutlined, CloseCircleOutlined, SearchOutlined } from '@ant-design/icons';
 
+import styles from './relatorio-editora.module.css';
+
 const RelatorioEditora = () => {
     const [form] = Form.useForm();
     const [modalVisible, setModalVisible] = useState(false);
@@ -140,6 +142,7 @@ const RelatorioEditora = () => {
                 name='editoraId'
                 label='Editora'
                 extra='Você pode selecionar mais de uma editora.'
+                className={styles.editoraFormItem}
                 rules={[{ required: false }]}
               >
                 <Select

--- a/src/pages/relatorios/editora/relatorio-editora.module.css
+++ b/src/pages/relatorios/editora/relatorio-editora.module.css
@@ -1,0 +1,7 @@
+.editoraFormItem :global(.ant-form-item-extra) {
+    padding-top: 3px;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.2;
+    color: #42424A;
+}


### PR DESCRIPTION
…e editora

Introdução de relatorio-editora.module.css para estilizar o texto extra no item de formulário editora. Aplicação da nova classe de módulo CSS para melhorar a aparência e a legibilidade das informações extras do formulário.